### PR TITLE
Add web-based time timer

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,4 @@
 # timetimer
-TimeTimer For web
+
+Web-based countdown timer with 30 and 60 minute presets.
+Open `index.html` in a web browser and click a button to start the timer.

--- a/index.html
+++ b/index.html
@@ -1,0 +1,81 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Time Timer</title>
+  <style>
+    body {
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      justify-content: center;
+      height: 100vh;
+      font-family: Arial, sans-serif;
+    }
+    #timerCanvas {
+      border: 1px solid #ccc;
+      border-radius: 50%;
+      background-color: #f5f5f5;
+    }
+    button {
+      margin: 5px;
+      padding: 10px 20px;
+    }
+  </style>
+</head>
+<body>
+  <canvas id="timerCanvas" width="200" height="200"></canvas>
+  <div>
+    <button onclick="startTimer(30)">30분</button>
+    <button onclick="startTimer(60)">60분</button>
+  </div>
+<script>
+let remainingSeconds = 0;
+let totalSeconds = 0;
+let intervalId;
+const canvas = document.getElementById('timerCanvas');
+const ctx = canvas.getContext('2d');
+
+function startTimer(minutes) {
+  clearInterval(intervalId);
+  totalSeconds = minutes * 60;
+  remainingSeconds = totalSeconds;
+  intervalId = setInterval(updateTimer, 1000);
+  updateTimer();
+}
+
+function updateTimer() {
+  if (remainingSeconds <= 0) {
+    clearInterval(intervalId);
+  }
+  drawTimer();
+  remainingSeconds -= 1;
+}
+
+function drawTimer() {
+  const radius = canvas.width / 2 - 10;
+  ctx.clearRect(0, 0, canvas.width, canvas.height);
+  ctx.beginPath();
+  ctx.arc(canvas.width/2, canvas.height/2, radius, 0, 2 * Math.PI);
+  ctx.strokeStyle = '#ddd';
+  ctx.lineWidth = 10;
+  ctx.stroke();
+
+  const progress = totalSeconds > 0 ? remainingSeconds / totalSeconds : 0;
+  const angle = -Math.PI / 2 + 2 * Math.PI * progress;
+  ctx.arc(canvas.width/2, canvas.height/2, radius, -Math.PI / 2, angle);
+  ctx.strokeStyle = '#f00';
+  ctx.lineWidth = 10;
+  ctx.stroke();
+
+  ctx.font = '20px Arial';
+  ctx.textAlign = 'center';
+  ctx.textBaseline = 'middle';
+  const mins = Math.floor(remainingSeconds / 60);
+  const secs = remainingSeconds % 60;
+  ctx.fillText(`${mins}:${secs.toString().padStart(2,'0')}`, canvas.width/2, canvas.height/2);
+}
+</script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add a simple HTML/CSS/JS time timer
- update README with brief usage instructions

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_687213eba1208321901b9dba7fc232af